### PR TITLE
Improve discoverability by pushing Co-Tracker to HF along with download stats

### DIFF
--- a/cotracker/models/core/cotracker/cotracker.py
+++ b/cotracker/models/core/cotracker/cotracker.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from cotracker.models.core.model_utils import sample_features4d, sample_features5d
 from cotracker.models.core.embeddings import (
     get_2d_embedding,
@@ -26,7 +28,7 @@ from cotracker.models.core.cotracker.blocks import (
 torch.manual_seed(0)
 
 
-class CoTracker2(nn.Module):
+class CoTracker2(nn.Module, PyTorchModelHubMixin):
     def __init__(
         self,
         window_len=8,


### PR DESCRIPTION
Hi @nikitakaraevv and others,

Thanks for this nice work. I wrote a quick PoC to showcase that you can easily have integration on the 🤗 hub, which greatly improves the discoverability of your models.

This PR shows how you can automatically load the various CoTracker models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from cotracker.models.core.cotracker.cotracker import CoTracker2

model = CoTracker2.from_pretrained("nielsr/co-tracker-hf")
```
The corresponding model is here for now: https://huggingface.co/nielsr/co-tracker-hf. We could move all checkpoints to separate repos on the [Meta organization](https://huggingface.co/facebook) if you're interested. Ideally, each checkpoint has its own model repository on the 🤗 hub, where a config.json and safetensors weights are hosted.

To improve discoverability, we could add tags like "object-tracking" to the model cards, so that people can find these models by either typing in the search bar/filtering on hf.co/models.

Kind regards,

Niels