### PR TITLE
Fix torch hub load error for cotracker v2 and v2.1

### DIFF
--- a/cotracker/models/build_cotracker.py
+++ b/cotracker/models/build_cotracker.py
@@ -24,13 +24,13 @@ def build_cotracker(
 
 
 def build_cotracker(checkpoint=None, offline=True, window_len=16, v2=False):
-    if offline:
-        cotracker = CoTrackerThreeOffline(
-            stride=4, corr_radius=3, window_len=window_len
-        )
+    if v2:
+        cotracker = CoTracker2(stride=4, window_len=window_len)
     else:
-        if v2:
-            cotracker = CoTracker2(stride=4, window_len=window_len)
+        if offline:
+            cotracker = CoTrackerThreeOffline(
+                stride=4, corr_radius=3, window_len=window_len
+            )
         else:
             cotracker = CoTrackerThreeOnline(
                 stride=4, corr_radius=3, window_len=window_len


### PR DESCRIPTION
This is due to two bugs in load_cotracker and predictor due to the api change from v2 to v3